### PR TITLE
End RAT dates for WA and NSW

### DIFF
--- a/R/make_RAT_validity_matrix.R
+++ b/R/make_RAT_validity_matrix.R
@@ -16,10 +16,13 @@ make_RAT_validity_matrix <- function(RAT_matrix) {
     RAT_valid_mat[] <- TRUE
     RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-06-30"),
                   colnames(RAT_valid_mat) == "VIC"] <- FALSE
-    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-08-23"),
-                  colnames(RAT_valid_mat) == "SA"] <- FALSE
     RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-09-01"),
                   colnames(RAT_valid_mat) == "QLD"] <- FALSE
+    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-10-01"),
+                  colnames(RAT_valid_mat) == "NSW"] <- FALSE
+    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-10-09"),
+                  colnames(RAT_valid_mat) == "WA"] <- FALSE
+
     #coerce to boolean
     RAT_valid_mat <- ifelse(RAT_valid_mat == 1,TRUE, FALSE)
 }

--- a/R/make_RAT_validity_matrix.R
+++ b/R/make_RAT_validity_matrix.R
@@ -16,11 +16,11 @@ make_RAT_validity_matrix <- function(RAT_matrix) {
     RAT_valid_mat[] <- TRUE
     RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-06-30"),
                   colnames(RAT_valid_mat) == "VIC"] <- FALSE
-    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-09-01"),
+    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-08-31"),
                   colnames(RAT_valid_mat) == "QLD"] <- FALSE
-    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-10-01"),
+    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-09-30"),
                   colnames(RAT_valid_mat) == "NSW"] <- FALSE
-    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-10-09"),
+    RAT_valid_mat[as.Date(rownames(RAT_valid_mat)) > as.Date("2023-10-08"),
                   colnames(RAT_valid_mat) == "WA"] <- FALSE
 
     #coerce to boolean

--- a/R/prepare_ascertainment_input.R
+++ b/R/prepare_ascertainment_input.R
@@ -114,6 +114,7 @@ get_CAR_from_surveys <- function(dates,
                                   state == "VIC" & date > as.Date('2023-06-30') ~ 0.00,
                                   state == "QLD" & date > as.Date('2023-08-31') ~ 0.00,
                                   state == "NSW" & date > as.Date('2023-09-30') ~ 0.00,
+                                  state == "WA" & date > as.Date("2023-10-08") ~ 0.00,
                                   TRUE ~ test_prob_given_infection))
     }
 


### PR DESCRIPTION
Added end dates for WA and NSW to rat validity matrix and prepare ascertainment functions. Removed SA from validity matrix function as they have retrospectively fixed this period