### PR TITLE
corrected completion prob calculation

### DIFF
--- a/R/create_infection_compl_mat.R
+++ b/R/create_infection_compl_mat.R
@@ -1,13 +1,33 @@
-create_infection_compl_mat <- function (convolution_matrices,
-                                        jurisdictions) {
+create_infection_compl_mat <- function (observable_infection_dates,
+                                        target_dates,
+                                        jurisdictions,
+                                        timevarying_delay_dist_ext) {
 
-    # with_named_dates <- lapply(convolution_matrices, function(x) {
-    #     row.names(x) <- as.character(infection_days)
-    #     colnames(x) <- as.character(infection_days)
-    #     x
-    # })
+    # get length of infection timeseries
+    n_days_infection_observable <- length(observable_infection_dates)
+
+    # make index for target days within the infection days
+    # basically this backs out extra left and right days
+    obs_data_idx <- which(observable_infection_dates %in% as.Date(target_dates))
+
+    # build convolution matrix
+    convolution_matrices <- lapply(1:n_jurisdictions, function(x)
+        get_convolution_matrix(timevarying_delay_dist_ext[, x],
+                               n_days_infection_observable))
+
+    # subset convolution matrix to target days
+    convolution_matrices <- lapply(convolution_matrices,
+                                   function(x){
+                                       x[obs_data_idx,obs_data_idx]
+                                   })
+    # set jurisdiction names
     with_named_jurisdictions <- setNames(convolution_matrices, #with_named_dates,
                                          jurisdictions)
+    # summarise completion probability by state
     inf_compl_prob_mat <- do.call(cbind, lapply(with_named_jurisdictions, colSums))
+
+    # put in date names
+    rownames(inf_compl_prob_mat) <- target_dates
+    # retun date by state object
     inf_compl_prob_mat
 }

--- a/tests/tests_manual.R
+++ b/tests/tests_manual.R
@@ -170,12 +170,16 @@ fit <- fit_model(model = m,
 
 # infection completion probability matrices
 PCR_infection_completion_prob_mat <- create_infection_compl_mat(
-    PCR_notification_model_objects$convolution_matrices,
-    jurisdictions)
+  observable_infection_dates = PCR_infection_days,
+  target_dates = target_dates,
+  jurisdictions = jurisdictions,
+  timevarying_delay_dist_ext = PCR_notification_delay_distribution)
 
 RAT_infection_completion_prob_mat <- create_infection_compl_mat(
-    RAT_notification_model_objects$convolution_matrices,
-    jurisdictions)
+  observable_infection_dates = RAT_infection_days,
+  target_dates = target_dates,
+  jurisdictions = jurisdictions,
+  timevarying_delay_dist_ext = RAT_notification_delay_distribution)
 
 # #check convergence
 # coda::gelman.diag(draws, autoburnin = FALSE, multivariate = FALSE)$psrf[, 1]


### PR DESCRIPTION
the previous issue was that we included the probability of an infection being observable in the future. This is no longer the case: by cutting off the future portions of the convolution matrix, the colsums now only sum the probabilities of being observed in each day within the target dates range